### PR TITLE
[PKG-13415] Update to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-crewai" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: eb39fa78067bad71e329c8eaa6aa6aa112a30bbf75f6648f308ba68247081aed
+  sha256: 23131f4113f462ec6203456c36ba9fee3195684eb24393dd50397c706ebd3e73
 
 build:
   number: 0
@@ -18,15 +18,13 @@ requirements:
   host:
     - pip
     - python
-    - poetry-core
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
-  run_constrained:
-    - crewai >=0.80.0,<0.81.0
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
 
 # Unable to run tests and check imports, crewai is not in the main channel.
 test:
@@ -50,5 +48,5 @@ extra:
   recipe-maintainers:
     - timkpaine
   skip-lints:
-    - invalid_url
+    - reachable_url
     - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
   run_constrained:
-    - crewai >=0.80.0,<0.81.0
+    - crewai >=1.0.0,<2.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,12 @@ requirements:
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
+  run_constrained:
+    - crewai >=0.80.0,<0.81.0
 
-# Unable to run tests and check imports, crewai is not in the main channel.
 test:
+  imports:
+    - opentelemetry.instrumentation.crewai
   commands:
     - pip check
   requires:


### PR DESCRIPTION
opentelemetry-instrumentation-crewai 0.57.0

**Destination channel:** defaults

### Links

- [PKG-13415]
- [Upstream repository](https://github.com/traceloop/openllmetry/tree/v0.57.0/packages/opentelemetry-instrumentation-crewai)

### Explanation of changes:

- Change build system to hatchling
- Adjust skip-lints
- Remove run-constrained pinning for crewai


[PKG-13415]: https://anaconda.atlassian.net/browse/PKG-13415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ